### PR TITLE
Add slack_message param to slack-notify-waiting-for-approval job [semver:minor]

### DIFF
--- a/src/jobs/slack-notify-waiting-for-approval.yml
+++ b/src/jobs/slack-notify-waiting-for-approval.yml
@@ -22,8 +22,13 @@ parameters:
     description: |
       Token used by Slack bot application.   Must have scopes `users:read`, `users:read.email`, and `chat:write`.
     default: ${SLACK_BOT_TOKEN}
+  slack_message:
+    default: "Pending Approval for ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_USERNAME}"
+    description: Slack Message to send
+    type: string
 executor: default
 steps:
   - slack-notify-waiting-for-approval:
       email_domain: <<parameters.email_domain>>
       slack_bot_token: <<parameters.slack_bot_token>>
+      slack_message: <<parameters.slack_message>>


### PR DESCRIPTION
## Description:

Add the `slack_message` parameter to the `slack-notify-waiting-for-approval` job.

## Motivation:

The `slack_message` parameter already exists for the `slack-notify-waiting-for-approval` command, but isn't exposed on the corresponding job. Add it to the job to make it usable in workflows using that job.