### PR TITLE
Add command for unpacking aws context vars [semver:minor]

### DIFF
--- a/src/commands/boostrap-aws-context-creds.yml
+++ b/src/commands/boostrap-aws-context-creds.yml
@@ -1,0 +1,7 @@
+description: |
+  Each CI context can inject an AWS credential to the environment.
+  Unpack them all and combine into a single credentials file inside ~/.aws/credentials
+steps:
+  - run:
+      name: Iterate through all context variables and unpack them
+      command: <<include(scripts/bootstrap_aws_context_creds.sh)>>

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -19,3 +19,4 @@ usage:
         - utils/slack-notify-waiting-for-approval:
             coda_prod_token: ${CODA_PROD_TOKEN}
             slack_bot_token: ${PUSH_REMINDER_BOT_TOKEN}
+        - utils/boostrap-aws-context-creds

--- a/src/scripts/bootstrap_aws_context_creds.sh
+++ b/src/scripts/bootstrap_aws_context_creds.sh
@@ -8,11 +8,6 @@ function run_main() {
     done;
 }
 
-function get_line() {
-    read -r line < ~/.aws/credentials
-    echo "$line"
-}
-
 # Will not run if sourced for bats.
 ORB_TEST_ENV="bats-core"
 if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then

--- a/src/scripts/bootstrap_aws_context_creds.sh
+++ b/src/scripts/bootstrap_aws_context_creds.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function run_main() {
+    rm -f ~/.aws/credentials
+    mkdir -p ~/.aws
+    set | grep ^CTX_AWS_BASE_64_CREDS_ | cut -d= -f2- | while read -r base64creds; do \
+        echo "$base64creds" | base64 -d >> ~/.aws/credentials; \
+    done;
+}
+
+function get_line() {
+    read -r line < ~/.aws/credentials
+    echo "$line"
+}
+
+# Will not run if sourced for bats.
+ORB_TEST_ENV="bats-core"
+if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
+    run_main
+fi

--- a/src/tests/test_bootstrap_creds.bats
+++ b/src/tests/test_bootstrap_creds.bats
@@ -1,0 +1,11 @@
+setup() {
+    export CTX_AWS_BASE_64_CREDS_TEST=Q3JlZHMgVGVzdCAxMjM=
+
+    source ./src/scripts/bootstrap_aws_context_creds.sh
+}
+
+@test '1: Unpack test variable' {
+    $(run_main)
+    first_line=$(get_line)
+    [[ "$first_line" == "Creds Test 123" ]]
+}

--- a/src/tests/test_bootstrap_creds.bats
+++ b/src/tests/test_bootstrap_creds.bats
@@ -6,6 +6,6 @@ setup() {
 
 @test '1: Unpack test variable' {
     $(run_main)
-    first_line=$(get_line)
+    first_line=$(head -n 1 ~/.aws/credentials)
     [[ "$first_line" == "Creds Test 123" ]]
 }


### PR DESCRIPTION
<!---
  Must include [semver:<type>] in PR title in order to publish new version
 -->

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
Many packages use aws credentials and we're repetitively adding a make command to unpack the variables. Putting it in the utils orb to make our configs cleaner.

## Test Plan
Created a simple test below, but also tested the command in the `infra` repo.
Pipeline - https://app.circleci.com/pipelines/github/coda/infra/8189/workflows/42d535ed-a083-478c-9d08-b95529b39d62/jobs/20023  | [Draft PR](https://github.com/coda/infra/pull/2420)

<img width="1480" alt="Screen Shot 2022-02-11 at 1 12 39 PM" src="https://user-images.githubusercontent.com/92751744/153670929-fefaf7db-dbf6-47dd-8159-4872587abcc8.png">

