### PR TITLE
Bring over CIRCLE_USERNAME from previous flow [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,13 @@ parameters:
     default: ''
 
 commands:
-  boostrap_pipeline_circleci_user:
+  bootstrap_pipeline_circleci_user:
     steps:
       - run:
           name: Initialize CIRCLE_USERNAME from pipeline
-          command: export CIRCLE_USERNAME=<< pipeline.parameters.circleci-user >>
+          command: |
+            echo "export CIRCLE_USERNAME=<< pipeline.parameters.circleci-user >>" >> $BASH_ENV
+            source $BASH_ENV
 
 jobs:
   integration-test-notify:
@@ -50,7 +52,7 @@ jobs:
     <<: *default_build_environment
     steps:
       - checkout
-      - boostrap_pipeline_circleci_user
+      - bootstrap_pipeline_circleci_user
       - utils/slack-notify-waiting-for-approval:
           slack_bot_token: ${PUSH_REMINDER_BOT_TOKEN}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,17 @@ parameters:
       A "dev:alpha" version must exist for the initial pipeline run.
     type: string
     default: "dev:alpha"
+  circleci-user:
+    description: The user who published orb changes
+    type: string
+    default: ''
 
 commands:
-
+  boostrap_pipeline_circleci_user:
+    steps:
+      - run:
+          name: Initialize CIRCLE_USERNAME from pipeline
+          command: export CIRCLE_USERNAME=<< pipeline.parameters.circleci-user >>
 
 jobs:
   integration-test-notify:
@@ -42,6 +50,7 @@ jobs:
     <<: *default_build_environment
     steps:
       - checkout
+      - boostrap_pipeline_circleci_user
       - utils/slack-notify-waiting-for-approval:
           slack_bot_token: ${PUSH_REMINDER_BOT_TOKEN}
 
@@ -91,6 +100,7 @@ workflows:
             - orb-publishing
           requires:
             - orb-tools/publish-dev
+          pipeline-param-map: '{\"run-integration-tests\": true, \"dev-orb-version\": \"dev:${CIRCLE_SHA1:0:7}\", \"circleci-user\": \"${CIRCLE_USERNAME}\"}'
 
   integration-test_deploy:
     when: << pipeline.parameters.run-integration-tests >>


### PR DESCRIPTION
<!---
  Must include [semver:<type>] in PR title in order to publish new version
 -->

**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [X] Patch

## Description:
Slack: https://codaproject.slack.com/archives/CMDFQBKBR/p1644948074083779

Our integration test is currently slacking Nigel each time as opposed to the person who triggered the job. Follow the two job standard for publishing orbs, the second job gets triggered via API after the first job finishes. It looks like this API call defaults Nigel to be the owner of the second job.

## Solution
I think we can use [pipeline-param-map](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-trigger-integration-tests-workflow) to pass the previous circleci-user. 

Not entirely sure if this will work so i'm ready to revert