### PR TITLE
Add context depedency to opsgenie  [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ workflows:
             - dockerhub
             - orb-publishing
             - util
+            - ops-genie
       - integration-test-slack:
           context:
             - dockerhub


### PR DESCRIPTION
<!---
  Must include [semver:<type>] in PR title in order to publish new version
 -->

**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [X] Patch

## Description:

Deleted project variables related to OpsGenie on the CircleCI app. Need to substitute them now with the ops-genie context to get credentials