### PR TITLE
add CIRCLE_BUILD_NUM [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ default_build_environment: &default_build_environment
 
 orbs:
   utils: coda/utils@<<pipeline.parameters.dev-orb-version>>
-  orb-tools: circleci/orb-tools@10.0.3
+  orb-tools: circleci/orb-tools@11.2.0
   bats: circleci/bats@1.0
   shellcheck: circleci/shellcheck@2.0
 
@@ -87,13 +87,14 @@ workflows:
             - bats/run
             - shellcheck/check
       # Publish development version of the orb.
-      - orb-tools/publish-dev:
+      - orb-tools/publish:
           publish-token-variable: ORB_PUBLISHING_TOKEN
           context:
             - dockerhub
             - orb-publishing
           orb-name: coda/utils
           requires: [hold-for-dev-publish]
+          vcs-type:  << pipeline.project.type >>
       # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -38,7 +38,7 @@ steps:
 - run:
     command: |
       echo '{}' | jq '{
-        "message": "[CircleCI] [#\(env.CIRCLE_PREVIOUS_BUILD_NUM)]: workflow \(env.CIRCLE_BRANCH) stage \(env.CIRCLE_STAGE) job \(env.CIRCLE_JOB)",
+        "message": "[CircleCI] [#\(env.CIRCLE_BUILD_NUM)]: workflow \(env.CIRCLE_BRANCH) stage \(env.CIRCLE_STAGE) job \(env.CIRCLE_JOB)",
         "alias": "\(env.CIRCLE_PROJECT_REPONAME)/\(env.CIRCLE_BRANCH)#\(env.CIRCLE_JOB)",
         "description":"See \(env.CIRCLE_BUILD_URL) for more details. ",
         "outcome": "failed",


### PR DESCRIPTION
Fix for https://codaproject.slack.com/archives/CMDFQBKBR/p1657324320753489

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Fix null 
Replacing 
```


CIRCLE_PREVIOUS_BUILD_NUM  This variable is likely to be deprecated, and CircleCI recommends users to avoid using it.




```

