### PR TITLE
[semver:minor] Use standard slack token name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - bootstrap_pipeline_circleci_user
       - utils/slack-notify-waiting-for-approval:
-          slack_bot_token: ${PUSH_REMINDER_BOT_TOKEN}
+          slack_bot_token: ${SLACK_ACCESS_TOKEN}
 
   integration-test-cancel-older-jobs:
     <<: *default_build_environment

--- a/src/commands/slack-notify-waiting-for-approval.yml
+++ b/src/commands/slack-notify-waiting-for-approval.yml
@@ -44,7 +44,7 @@ parameters:
     type: string
     description: |
       Token used by Slack bot application.   Must have scopes `users:read`, `users:read.email`, and `chat:write`.
-    default: ${PUSH_REMINDER_BOT_TOKEN}
+    default: ${SLACK_ACCESS_TOKEN}
   on_failure:
     default: false
     description: Failure information of circleci build
@@ -77,7 +77,7 @@ steps:
         name: Send Slack Message
         command: |
           set -eo pipefail
-          curl -X POST -H "Authorization: Bearer $PUSH_REMINDER_BOT_TOKEN" \
+          curl -X POST -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" \
             -H "Content-Type: application/json" -d \
             "{ \
               \"channel\": \"${SLACK_USER_ID}\", \

--- a/src/commands/slack-notify-waiting-for-approval.yml
+++ b/src/commands/slack-notify-waiting-for-approval.yml
@@ -77,7 +77,7 @@ steps:
         name: Send Slack Message
         command: |
           set -eo pipefail
-          curl -X POST -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" \
+          curl --fail-with-body -X POST -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" \
             -H "Content-Type: application/json" -d \
             "{ \
               \"channel\": \"${SLACK_USER_ID}\", \

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -18,5 +18,5 @@ usage:
             circle_token: ${CIRCLECI_TOKEN}
         - utils/slack-notify-waiting-for-approval:
             coda_prod_token: ${CODA_PROD_TOKEN}
-            slack_bot_token: ${PUSH_REMINDER_BOT_TOKEN}
+            slack_bot_token: ${SLACK_ACCESS_TOKEN}
         - utils/bootstrap-aws-context-creds

--- a/src/jobs/slack-notify-waiting-for-approval.yml
+++ b/src/jobs/slack-notify-waiting-for-approval.yml
@@ -13,7 +13,7 @@ parameters:
     type: string
     default: coda.io
   slack_bot_token:
-    default: $PUSH_REMINDER_BOT_TOKEN
+    default: $SLACK_ACCESS_TOKEN
     type: string
     description: |
       Token used by Slack bot application.   Must have scopes `users:read`, `users:read.email`, and `chat:write`.

--- a/src/tests/test_user_handles.bats
+++ b/src/tests/test_user_handles.bats
@@ -21,7 +21,7 @@ setup() {
 @test '4: Check Codas Slack Handle Exists' {
     export CIRCLE_USERNAME="gita-codaio"
     export EMAIL_DOMAIN="coda.io"
-    export SLACK_BOT_TOKEN=$PUSH_REMINDER_BOT_TOKEN
+    export SLACK_BOT_TOKEN=$SLACK_ACCESS_TOKEN
     result=$(run_main)
     [[ "$result" == *"U01DJE1DABE"* ]]
 }


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [X] Minor
- [ ] Patch

This is the token name used by the slack orb provided by CircleCI. We can standardize on that.
Also fail on non-200 responses from `curl` and had to change ORB_PUBLISHING_TOKEN -> CIRCLECI_TOKEN.

PTAL https://github.com/orgs/coda/teams/internal-tools