### PR TITLE
rm curl option

### DIFF
--- a/src/commands/slack-notify-waiting-for-approval.yml
+++ b/src/commands/slack-notify-waiting-for-approval.yml
@@ -77,7 +77,7 @@ steps:
         name: Send Slack Message
         command: |
           set -eo pipefail
-          curl --fail-with-body -X POST -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" \
+          curl --fail -X POST -H "Authorization: Bearer $SLACK_ACCESS_TOKEN" \
             -H "Content-Type: application/json" -d \
             "{ \
               \"channel\": \"${SLACK_USER_ID}\", \


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Remove  [curl: option --fail-with-body: is unknown](https://codaproject.slack.com/archives/CMDFQBKBR/p1668468522969059?thread_ts=1668016201.350519&cid=CMDFQBKBR)
config repo is on diff version of curl that doesn't  have this option (v 7.64.0)