### PR TITLE
publish using github release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
   lint-pack:
     when:
       not:
-        equal: [ main, << pipeline.git.branch >> ]
+        equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack
       # https://www.shellcheck.net/wiki/SC2002
@@ -67,7 +67,7 @@ workflows:
 
   publish:
     when:
-      equal: [ main, << pipeline.git.branch >> ]
+      equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,9 @@ workflows:
 
   publish:
     when:
-      matches: { pattern: "^v*" , value: << pipeline.git.tag >> }
+      matches:
+        pattern: "^v*"
+        value: << pipeline.git.tag >>
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,3 +77,6 @@ workflows:
           orb-name: coda/utils
           pub-type: production
           vcs-type: << pipeline.project.type >>
+          filters:
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,11 @@ parameters:
     type: string
     default: ''
 
-
 workflows:
   lint-pack:
+    when:
+      not:
+        equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack
       # https://www.shellcheck.net/wiki/SC2002
@@ -64,16 +66,14 @@ workflows:
                   ignore: main
 
   publish:
+    when:
+      equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/publish:
           context: 
             - dockerhub
             - orb-publishing
             - util
-          filters:
-            branches:
-              only:
-                - main
           orb-name: coda/utils
           pub-type: production
           vcs-type: << pipeline.project.type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
 
   publish:
     when:
-      matches: { pattern: '/^v[0-9]+\.[0-9]+\.[0-9]+$/', value: << pipeline.git.tag >> }
+      matches: { pattern: "^v*" , value: << pipeline.git.tag >> }
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
   lint-pack:
     when:
       not:
-        equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
+        equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack
       # https://www.shellcheck.net/wiki/SC2002
@@ -67,7 +67,7 @@ workflows:
 
   publish:
     when:
-      equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
+      equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,12 @@ parameters:
     type: string
     default: ''
 
+
 workflows:
   lint-pack:
     when:
       not:
-        equal: [ main, << pipeline.git.branch >> ]
+        equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack
       # https://www.shellcheck.net/wiki/SC2002
@@ -50,7 +51,7 @@ workflows:
           requires:
             - orb-tools/pack
             - shellcheck/check
-          vcs-type: github
+          vcs-type: << pipeline.project.type >>
       - orb-tools/continue:
           context:
             - dockerhub
@@ -67,9 +68,13 @@ workflows:
 
   publish:
     when:
-      equal: [ main, << pipeline.git.branch >> ]
+      equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
     jobs:
+      - create-tag-on-github-release-page:
+          type: approval
       - orb-tools/publish:
+          requires:
+            - create-tag-on-github-release-page
           context: 
             - dockerhub
             - orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ workflows:
             - orb-tools/pack
             - shellcheck/check
           vcs-type: << pipeline.project.type >>
-      - orb-tools/continue:
+      - orb-tools/continue: # continues to .circleci/test-deploy.yml
           context:
             - dockerhub
             - orb-publishing
@@ -69,7 +69,10 @@ workflows:
   publish:
     when: << pipeline.git.tag >>
     jobs:
-      - orb-tools/pack
+      - orb-tools/pack:
+          filters:
+            tags:
+              only: /^v.*/
       - orb-tools/publish:
           requires:
             - orb-tools/pack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ workflows:
         pattern: ^v[0-9]+\.[0-9]+\.[0-9]+$
         value: << pipeline.git.tag >>
     jobs:
+      - orb-tools/pack
       - orb-tools/publish:
           context: 
             - dockerhub
@@ -80,6 +81,8 @@ workflows:
           orb-name: coda/utils
           pub-type: production
           vcs-type: << pipeline.project.type >>
+          requires: 
+            - orb-tools/pack
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ workflows:
   lint-pack:
     when:
       not:
-        equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
+        equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack
       # https://www.shellcheck.net/wiki/SC2002
@@ -68,10 +68,8 @@ workflows:
 
   publish:
     when:
-      equal: [ gv-main-branch-filter, << pipeline.git.branch >> ]
+      matches: { pattern: '/^v[0-9]+\.[0-9]+\.[0-9]+$/', value: << pipeline.git.tag >> }
     jobs:
-      - create-tag-on-github-release-page:
-          type: approval
       - orb-tools/publish:
           requires:
             - create-tag-on-github-release-page

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,13 +67,12 @@ workflows:
                   ignore: main
 
   publish:
-    when:
-      matches:
-        pattern: ^v[0-9]+\.[0-9]+\.[0-9]+$
-        value: << pipeline.git.tag >>
+    when: << pipeline.git.tag >>
     jobs:
       - orb-tools/pack
       - orb-tools/publish:
+          requires:
+            - orb-tools/pack
           context: 
             - dockerhub
             - orb-publishing
@@ -81,8 +80,6 @@ workflows:
           orb-name: coda/utils
           pub-type: production
           vcs-type: << pipeline.project.type >>
-          requires: 
-            - orb-tools/pack
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,9 @@ workflows:
 
   publish:
     when:
-      and: 
-        - matches: { pattern: '/^v[0-9]+\.[0-9]+\.[0-9]+$/', value: << pipeline.git.tag >> }
+      matches:
+        pattern: ^v[0-9]+\.[0-9]+\.[0-9]+$
+        value: << pipeline.git.tag >>
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,10 @@ workflows:
                   ignore: main
 
   publish:
-    when: << pipeline.git.tag >>
+    when:
+      matches:
+        pattern: ^v[0-9]+\.[0-9]+\.[0-9]+$
+        value: << pipeline.git.tag >>
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,6 @@ workflows:
       matches: { pattern: '/^v[0-9]+\.[0-9]+\.[0-9]+$/', value: << pipeline.git.tag >> }
     jobs:
       - orb-tools/publish:
-          requires:
-            - create-tag-on-github-release-page
           context: 
             - dockerhub
             - orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,7 @@ parameters:
 workflows:
   lint-pack:
     when:
-      not:
-        equal: [ main, << pipeline.git.branch >> ]
+      equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack
       # https://www.shellcheck.net/wiki/SC2002

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,7 @@ workflows:
                   ignore: main
 
   publish:
-    when:
-      matches:
-        pattern: ^v[0-9]+\.[0-9]+\.[0-9]+$
-        value: << pipeline.git.tag >>
+    when: << pipeline.git.tag >>
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ parameters:
 workflows:
   lint-pack:
     when:
-      equal: [ main, << pipeline.git.branch >> ]
+      not:
+        equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - orb-tools/pack
       # https://www.shellcheck.net/wiki/SC2002
@@ -67,9 +68,8 @@ workflows:
 
   publish:
     when:
-      matches:
-        pattern: "^v*"
-        value: << pipeline.git.tag >>
+      and: 
+        - matches: { pattern: '/^v[0-9]+\.[0-9]+\.[0-9]+$/', value: << pipeline.git.tag >> }
     jobs:
       - orb-tools/publish:
           context: 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -50,6 +50,9 @@ jobs:
 
 workflows:
   test-deploy:
+    when:
+      not:
+        equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - integration-test-notify:
           context:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 ### How to Publish
 * Create and push a branch with your new features.
 * When ready to publish a new production version, create a Pull Request from from _feature branch_ to `main`.
-* When your branch is merged into `main` create a new release version off of `main`. This can be achieved by going to [circleci-utils](https://github.com/coda/circleci-utils/releases/new) release page and clicking on `Draft a new release`. Make sure the release version begins with `v`. This is version number that will match the new orb version.
+* When your branch is merged into `main` create a new release version off of `main`. This can be achieved by going to [circleci-utils](https://github.com/coda/circleci-utils/releases/new) release page and clicking on `Draft a new release`. 
+Make sure the release version is in the format of `vX.X.X`. This is version number that will match the new orb version.
 
 ### How to Publish Dev Version
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 [Example Usage](src/examples/example.yml)
 ### How to Publish
 * Create and push a branch with your new features.
-* When ready to publish a new production version, create a Pull Request from fore _feature branch_ to `main`.
+* When ready to publish a new production version, create a Pull Request from from _feature branch_ to `main`.
+* When your branch is merged into `main` create a new release version off of `main`. This can be achieved by going to [circleci-utils](https://github.com/coda/circleci-utils/releases/new) release page and clicking on `Draft a new release`. Make sure the release version begins with `v`. This is version number that will match the new orb version.
 
 ### How to Publish Dev Version
 
 Push your branch and CI will trigger dev published version of orb with the commit hash as the version.
 
-### How to Publish Dev VersionManually
+### How to Publish Dev Version Manually
 
 To manually pack your `orb.yml`, you can run `circleci orb pack .  > orb.yml` at the `@orb.yml` level.
 


### PR DESCRIPTION
## Description:
Previously workflow did not run on main because the key `setup: true` does not allow multiple workflows.
Tested by creating tag `v2.6.15` and setting it to `gv-main-branch-filter` -- see pipeline [here](https://app.circleci.com/pipelines/github/coda/circleci-utils/511/workflows/7965de26-bf65-4c24-8dfd-affa89ce136d) that triggered a publish workflow
[From Circle docs:
](https://support.circleci.com/hc/en-us/articles/360060934851-Troubleshooting-Error-Message-Max-number-of-workflows-exceeded-)
New version created [here](https://circleci.com/developer/orbs/orb/coda/utils?version=2.6.15)
```
CircleCI Dynamic Configuration, formally known as Setup Workflow, allows for a maximum of 1 workflow in the initial setup workflow. So if setup: true is set then the following config would be invalid:
Note: More than one workflow can be defined within a dynamic config, and the above error can be avoided as long as conditional parameters are set so that only one workflow will be executed.
```
To fix we added a filter mechanism on the tag level; this release tag also corresponds to the new version of the orb.

Also updated the docs and added in a filter mechanism to work with the git tag; since the git tags are not able to be filter it just looks if it begins with `v`; however, the tag needs to have the format of `vX.X.X` in order to publish a new version. See[ CI thread here](https://discuss.circleci.com/t/cant-trigger-workflow-on-git-tag-push-using-when-condition/43252/6)
We have to add this filter on both the `workflow` level and the `job` level of the `publish` workflow because there is a bug in [CircleCI] (https://github.com/circleci/circleci-docs/issues/6148#issuecomment-1053874240)

**The New Workflow for Publishing Production Version Orbs**
When an orb is merged the author needs to create a new release tag off of main. After it is created, this new tag will trigger a pipeline run to  publish the new orb with the same version as the github tag version. The version must be in the format of `vX.X.X`
Previously; we would update the version of the orb using the PR body and including a semver version in the title; the orb would read the PR's title and update based on that. 
To Do:
add descrion for /continue workflow and test-deploy
Note: 
Lots of commits because each git tag needed a new commit to test

The `continuation` in the `lint-pack` workflow is what triggers the `test-deploy` yaml file. The workflow continues by trigger everything in the `lint-pack` and when it is completed will automatically trigger `test-deploy`.  Full description of how this workflow work is described in `orb-tools` [here](https://circleci.com/developer/orbs/orb/circleci/orb-tools#usage-step1_lint-pack)