### PR TITLE
Fix up opsgenie alerts

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -38,7 +38,7 @@ steps:
 - run:
     command: |
       echo '{}' | jq '{
-        "message": "[CircleCI] [#\(env.CIRCLE_PREVIOUS_BUILD_NUM)]: workflow \(env.CIRCLE_BRANCH) stage \(env.CIRCLE_STAGE) job \(env.CIRCLE_JOB)",
+        "message": "[CircleCI] \(env.CIRCLE_PROJECT_REPONAME) repo: \(env.CIRCLE_JOB) failed on \(env.CIRCLE_BRANCH) branch",
         "alias": "\(env.CIRCLE_PROJECT_REPONAME)/\(env.CIRCLE_BRANCH)#\(env.CIRCLE_JOB)",
         "description":"See \(env.CIRCLE_BUILD_URL) for more details. ",
         "outcome": "failed",
@@ -65,7 +65,7 @@ steps:
     command: |
       if [ -n "${USER_EMAIL}" ]; then
         cat /tmp/raw-webhook.json | jq --arg USER_EMAIL $USER_EMAIL \
-        '.responders += [{"username": "'$USER_EMAIL'", "type": "user"}, {"name": "ci_alerts", "type": "team"}]' | \
+        '.responders += [{"username": "'$USER_EMAIL'", "type": "user"}, {"name": "buildcop", "type": "team"}]' | \
         jq --arg USER_EMAIL $USER_EMAIL '.details.user = $USER_EMAIL'> /tmp/webhook_temp.json
         mv /tmp/webhook_temp.json /tmp/raw-webhook.json
       fi


### PR DESCRIPTION
The current opsgenie alert titles are completely unintelligible:

> [CircleCI] [#null]: workflow main stage null job deploy-head

This should make them reasonable:

> [CircleCI] coda repo: deploy-head failed on main branch

Also routing alerts directly to buildcop instead of ci_alerts.

I was rewriting this in typescript, but I decided that's a much bigger can of worms than I want to open right now. Let's try to successfully get a new build of this orb out first, then get node in all the environments this runs, then we can consider rewriting.